### PR TITLE
Fix: Correctly display quotes in logs

### DIFF
--- a/ml2mqtt/templates/logs_raw.html
+++ b/ml2mqtt/templates/logs_raw.html
@@ -1,1 +1,1 @@
-{{ logs | join('\n') }}
+{{ logs | map('safe') | join('\n') }}


### PR DESCRIPTION
The log page was showing HTML-escaped quotes (`&#34;`) instead of actual double quote characters. This was due to Jinja2's default autoescaping behavior when rendering the raw log data.

This commit modifies `ml2mqtt/templates/logs_raw.html` to use the `|map('safe')` filter on the log lines. This ensures that log content is rendered as-is, preventing HTML entities from being displayed.

Additionally, I verified that the log page already uses AJAX for updates, so no changes were needed for that aspect beyond confirming its existing functionality.