### PR TITLE
feat: Implement HTML templating for postprocessor configuration

### DIFF
--- a/ml2mqtt/routes/model_routes.py
+++ b/ml2mqtt/routes/model_routes.py
@@ -428,6 +428,18 @@ def init_model_routes(model_manager: ModelManager):
         except TemplateNotFound:
             return jsonify({"error": "Template not found"}), 404
 
+    @model_bp.route("/render_postprocessor/<string:postprocessor_type>", methods=["POST"])
+    def render_postprocessor(postprocessor_type):
+        # In the future, we might want to pass data to the template,
+        # similar to how 'sensors' are passed to preprocessor templates.
+        # For now, an empty context is sufficient.
+        # data = request.get_json()
+        # context = data.get("context", {}) 
+        try:
+            return render_template(f"postprocessors/{postprocessor_type}.html") #, **context)
+        except TemplateNotFound:
+            return jsonify({"error": "Template not found"}), 404
+
     @model_bp.route("/mqtt_history/<string:modelName>", methods=["GET"])
     def render_mqtt(modelName: str) -> Response:
         return jsonify(model_manager.getModel(modelName).getRecentMqtt())

--- a/ml2mqtt/templates/edit_model/postprocessors.html
+++ b/ml2mqtt/templates/edit_model/postprocessors.html
@@ -165,6 +165,8 @@
   const addPostprocessorUrl = "{{ url_for('model.addPostprocessor', modelName=model.name) }}";
   const deletePostprocessorUrl = "{{ url_for('model.deletePostprocessor', modelName=model.name) }}";
   const reorderPostprocessorsUrl = "{{ url_for('model.reorderPostprocessors', modelName=model.name) }}";
+  const renderPostprocessorUrlPlaceholder = "{{ url_for('model.render_postprocessor', postprocessor_type='__PLACEHOLDER__') }}";
+  let appendedPostprocessorScripts = []; // For managing dynamic scripts
 
   function togglePostprocessorModal() {
     const modal = document.getElementById("postprocessorModal");
@@ -190,7 +192,7 @@
     const paramsContainer = document.getElementById("postParamsContainer");
     const descriptionContainer = document.getElementById("postDescription");
 
-    paramsContainer.innerHTML = "";
+    paramsContainer.innerHTML = ""; // Clear previous content
     descriptionContainer.classList.remove("visible");
 
     const selectedProcessor = availablePostprocessors.find(p => p.type === type);
@@ -199,49 +201,66 @@
     descriptionContainer.textContent = selectedProcessor.description || "";
     setTimeout(() => descriptionContainer.classList.add("visible"), 10);
 
-    const properties = selectedProcessor.config_schema?.properties || {};
+    // Fetch and render HTML template
+    const url = renderPostprocessorUrlPlaceholder.replace("__PLACEHOLDER__", type);
 
-    if (Object.keys(properties).length === 0) {
-      paramsContainer.style.display = "none";
-      return;
-    } else {
-      paramsContainer.style.display = "block";
-    }
+    fetch(url, {
+        method: "POST", // Match the route's method
+        headers: {
+            "Content-Type": "application/json"
+            // If you need to send a body, like preprocessors do for 'sensors':
+            // body: JSON.stringify({ /* any data needed by postprocessor templates */ })
+        }
+    })
+    .then(response => response.text())
+    .then(html => {
+        // Clean up previously appended scripts
+        if (appendedPostprocessorScripts.length > 0) {
+            for(const script of appendedPostprocessorScripts) {
+                document.body.removeChild(script);
+            }
+            appendedPostprocessorScripts = [];
+        }
 
-    for (const [paramName, paramConfig] of Object.entries(properties)) {
-      const fieldDiv = document.createElement("div");
-      fieldDiv.className = "formField";
+        paramsContainer.innerHTML = html;
+        paramsContainer.style.display = "block"; // Ensure it's visible
 
-      const label = document.createElement("label");
-      label.textContent = paramConfig.description || paramName;
-      label.htmlFor = `postParam_${paramName}`;
-
-      const input = document.createElement("input");
-      input.type = paramConfig.type === "integer" ? "number" : "text";
-      input.id = `postParam_${paramName}`;
-      input.value = paramConfig.default || "";
-
-      fieldDiv.appendChild(label);
-      fieldDiv.appendChild(input);
-      paramsContainer.appendChild(fieldDiv);
-    }
+        // Find and execute script tags within the loaded HTML
+        const scripts = paramsContainer.querySelectorAll("script");
+        scripts.forEach(script => {
+            const newScript = document.createElement("script");
+            newScript.textContent = script.textContent;
+            document.body.appendChild(newScript);
+            appendedPostprocessorScripts.push(newScript);
+        });
+    })
+    .catch(err => {
+        console.error("Error loading postprocessor template:", err);
+        paramsContainer.innerHTML = "<p>Error loading configuration.</p>";
+        paramsContainer.style.display = "block";
+    });
   }
 
   function submitPostprocessor() {
     const type = document.getElementById("postType").value;
-    const selectedProcessor = availablePostprocessors.find(p => p.type === type);
-    if (!selectedProcessor) return;
+    // const selectedProcessor = availablePostprocessors.find(p => p.type === type); // Not strictly needed anymore for param collection
+    // if (!selectedProcessor) return;
 
     const params = {};
-    const properties = selectedProcessor.config_schema?.properties || {};
+    const paramsContainer = document.getElementById("postParamsContainer");
+    const inputs = paramsContainer.querySelectorAll("input, select, textarea"); // Add other types if necessary
 
-    for (const paramName of Object.keys(properties)) {
-      const input = document.getElementById(`postParam_${paramName}`);
-      if (input) {
-        const value = input.type === "number" ? parseInt(input.value) : input.value;
-        params[paramName] = value;
-      }
-    }
+    inputs.forEach(input => {
+        // Handle checkboxes if you add them
+        // if (input.type === "checkbox") {
+        //     params[input.name] = input.checked;
+        // } else 
+        if (input.type === "number") {
+            params[input.name] = parseFloat(input.value);
+        } else {
+            params[input.name] = input.value;
+        }
+    });
 
     const payload = { type, params };
 
@@ -251,7 +270,10 @@
       body: JSON.stringify(payload)
     }).then(res => {
       if (res.ok) window.location.reload();
-      else showToast("Error adding postprocessor", true);
+      else showToast("Error adding postprocessor", true); // Ensure showToast is defined or handle error appropriately
+    }).catch(err => {
+        console.error("Error submitting postprocessor:", err);
+        // showToast might not be available, consider simple alert or console log
     });
   }
 

--- a/ml2mqtt/templates/postprocessors/majority_vote.html
+++ b/ml2mqtt/templates/postprocessors/majority_vote.html
@@ -1,0 +1,9 @@
+{% extends "postprocessors/postprocessor_base.html" %}
+
+{% block content %}
+<div class="formField">
+  <label for="window_size">Window Size:</label>
+  <input type="number" id="window_size" name="window_size" value="{{ config.window_size | default(5) }}" min="1">
+  <small>Number of results to consider for majority voting (e.g., 5).</small>
+</div>
+{% endblock %}

--- a/ml2mqtt/templates/postprocessors/only_diff.html
+++ b/ml2mqtt/templates/postprocessors/only_diff.html
@@ -1,0 +1,8 @@
+{% extends "postprocessors/postprocessor_base.html" %}
+
+{% block content %}
+<div class="formField">
+  <p>This postprocessor drops results unless they differ from the previous one.</p>
+  <p>No configuration is needed.</p>
+</div>
+{% endblock %}

--- a/ml2mqtt/templates/postprocessors/postprocessor_base.html
+++ b/ml2mqtt/templates/postprocessors/postprocessor_base.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Postprocessor Configuration</title>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
This change refactors the postprocessor configuration UI to use HTML templates, similar to how preprocessors are handled.

Key changes include:
- Added a base HTML template for postprocessors (`postprocessors/postprocessor_base.html`).
- Created specific HTML templates for `only_diff` and `majority_vote` postprocessors.
- Introduced a new `/render_postprocessor/<type>` route in `model_routes.py` to serve these templates.
- Updated the JavaScript in `edit_model/postprocessors.html`:
    - `updatePostParamUI` now fetches and injects HTML from the new route.
    - `submitPostprocessor` now correctly collects parameters from the loaded HTML form.

This provides a more flexible and maintainable way to define configuration interfaces for postprocessors.